### PR TITLE
Update bindgen dependency to v0.62

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ rand = "0.8"
 [build-dependencies]
 # https://tracker.debian.org/pkg/rust-bindgen
 # https://pkgs.org/search/?q=rust-bindgen
-bindgen = { version = "0.60", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.62", default-features = false, features = ["runtime"] }
 # https://tracker.debian.org/pkg/rust-pkg-config
 # https://pkgs.org/search/?q=rust-pkg-config
 pkg-config = "0.3.25"


### PR DESCRIPTION
Bump up the bindgen version to pick up the fixes discussed here:
https://github.com/rust-lang/rust-bindgen/issues/2312

Currently, libnotcurses-sys will not build on macos 13.5 because of this incompatibility.